### PR TITLE
Correct grammar in strapline

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
           <a id="forkme_banner" href="https://github.com/toto-framework/toto">View on GitHub</a>
 
           <h1 id="project_title">Toto</h1>
-          <h2 id="project_tagline">A framework define and secure the integrity of software supply chains</h2>
+          <h2 id="project_tagline">A framework to define and secure the integrity of software supply chains</h2>
 
             <section id="downloads">
               <a class="zip_download_link" href="https://github.com/toto-framework/toto/zipball/master">Download this project as a .zip file</a>


### PR DESCRIPTION
`A framework define` doesn't read correctly, presuming this should have `to` added but other reformulations would work too.